### PR TITLE
Remove Scruntinizr’s access-token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
   - php ./vendor/phpunit/phpunit/phpunit --coverage-clover=build/logs/clover.xml
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --access-token="80b65a15a783f3ca91af2635f701052e94179ebf84aad0a031dcc90dddd30394" --format=php-clover  build/logs/clover.xml
+  - php ocular.phar code-coverage:upload --format=php-clover  build/logs/clover.xml
 after_success:
   - wget https://github.com/satooshi/php-coveralls/releases/download/v1.0.0/coveralls.phar
   - travis_retry php coveralls.phar


### PR DESCRIPTION
Apparently its not needed for public repositories.